### PR TITLE
feat: respect user `guicursor`

### DIFF
--- a/lua/debugmaster/plugins.lua
+++ b/lua/debugmaster/plugins.lua
@@ -18,7 +18,7 @@ plugins.cursor_hl = (function()
       end
 
       local cursor_mode_off = vim.o.guicursor
-      local cursor_mode_on = "a:dCursor"
+      local cursor_mode_on = cursor_mode_off .. ",a:dCursor"
 
       api.nvim_create_autocmd("User", {
         pattern = "DebugModeChanged",

--- a/lua/debugmaster/plugins.lua
+++ b/lua/debugmaster/plugins.lua
@@ -16,12 +16,9 @@ plugins.cursor_hl = (function()
       if next(dcursor) == nil then
         api.nvim_set_hl(0, "dCursor", { bg = "#2da84f" })
       end
-      local cursor_mode_off = "n-v-sm:block,i-ci-ve-c:ver25,r-cr-o:hor20"
-      local cursor_mode_on = "n-v-sm:block-dCursor,i-ci-ve-c:ver25-dCursor,r-cr-o:hor20"
-      if vim.fn.has("nvim-0.11") == 1 then
-        cursor_mode_on = cursor_mode_on .. ",t:ver25"
-        cursor_mode_off = cursor_mode_off .. ",t:ver25"
-      end
+
+      local cursor_mode_off = vim.o.guicursor
+      local cursor_mode_on = "a:dCursor"
 
       api.nvim_create_autocmd("User", {
         pattern = "DebugModeChanged",


### PR DESCRIPTION
Resolved #12 

This PR ensures that the guicursor setting is respected based on the user’s configuration. Ideally, we shouldn’t hardcode changes to guicursor when debug mode is disabled. Also, since the primary purpose of this function—based on its name—is to modify the cursor highlight only, we should avoid altering anything beyond the highlight itself.

However, if modifying guicursor even when debug mode is enabled was your original intention, I can revert that part of the change.