### PR TITLE
fix: set buffer for keymapping when initializing breakpoint setting

### DIFF
--- a/lua/debugmaster/ui/Breakpoints.lua
+++ b/lua/debugmaster/ui/Breakpoints.lua
@@ -124,7 +124,7 @@ function Breakpoints.new()
         vim.cmd("normal " .. bp.line .. "G")
       end
     end
-  end)
+  end, { buffer = self.buf })
 
   dap.listeners.after.setBreakpoints["debugmaster"] = function()
     self._tree:render()


### PR DESCRIPTION
Prevent `CR` mappings from being overridden globally when initializing breakpoints setting.